### PR TITLE
feat: API review

### DIFF
--- a/examples/deno.js
+++ b/examples/deno.js
@@ -1,4 +1,4 @@
-import { ExtismPlugin, ExtismPluginOptions } from '../src/deno/mod.ts'
+import { createPlugin, ExtismPluginOptions } from '../src/deno/mod.ts'
 
 async function main() {
     const filename = Deno.args[0] || "wasm/hello.wasm";
@@ -12,7 +12,7 @@ async function main() {
         .withConfig("thing", "testing")
         .withWasi();
 
-    const plugin = await ExtismPlugin.new(wasm, options);
+    const plugin = await createPlugin(wasm, options);
 
     const res = await plugin.call(funcname, new TextEncoder().encode(input));
     const s = new TextDecoder().decode(res.buffer);

--- a/examples/index.html
+++ b/examples/index.html
@@ -58,6 +58,8 @@
     <script type="module" src="/dist/browser/index.mjs"></script>
 
     <script type="module">
+        import { createPlugin } from '/dist/browser/index.mjs';
+
         async function runPlugin() {
             // Get values from input fields
             const url = document.getElementById('url').value;
@@ -70,12 +72,11 @@
             }
 
             const options = new ExtismPluginOptions()
-                .withConfig("thing", "Charles")
-                .withConfig("name", "Charles")
+                .withConfig("thing", "testing")
                 .withWasi()
                 .withAllowedHosts(hosts);
 
-            const plugin = await ExtismPlugin.new(wasm, options);
+            const plugin = await createPlugin(wasm, options);
 
             const res = await plugin.call(funcname, new TextEncoder().encode(input));
             const s = new TextDecoder().decode(res.buffer);

--- a/examples/node.js
+++ b/examples/node.js
@@ -1,5 +1,5 @@
-const { ExtismPlugin, ExtismPluginOptions } = require("../dist/node/index")
-const { argv } = require("node:process");
+const { createPlugin, ExtismPluginOptions } = require("../dist/node/index")
+const { argv } = require("process");
 
 async function main() {
     const filename = argv[2] || "wasm/hello.wasm";
@@ -14,7 +14,7 @@ async function main() {
         .withWasi()
         .withAllowedHost("*.typicode.com");
 
-    const plugin = await ExtismPlugin.new(wasm, options);
+    const plugin = await createPlugin(wasm, options);
 
     const res = await plugin.call(funcname, new TextEncoder().encode(input));
     const s = new TextDecoder().decode(res.buffer);


### PR DESCRIPTION
This PR fixes #4 and addresses some of the points of #6 

- [x] Export `createPlugin` instead of `ExtismPlugin.new` to be more idiomatic for JS developers.
- [ ] Sync README with Ruby SDK. I decided to include this in the PR since it depends on the new APIs
- [ ] Stream incoming wasm plugin data if possible, especially if we're in the browser
- [ ] Accept a URL for both `ManifestWasmFile` and `ManifestWasmUrl`