### PR TITLE
ci: create an action to release to npm automatically when a new git tag is created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Publish package to NPM
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        rust:
+          - stable
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v3.8.1
+    
+    - name: Setup Deno
+      uses: denoland/setup-deno@v1.1.2
+    
+    - name: NPM install with caching
+      run: npm install
+
+    - name: Build
+      run: npm run build
+
+    - name: Node Test
+      run: npm run test
+      
+    - name: Deno Test
+      run: deno test -A ./tests/mod.test.ts
+
+    - name: Update package version
+      run: |
+        TAG=$(git describe --tags --abbrev=0)
+        echo "Latest Git tag: $TAG"
+        npm version $TAG --no-git-tag-version --no-commit-hooks
+
+    - name: NPM Publish
+      uses: JS-DevTools/npm-publish@v2.2.2
+      with:
+        token: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@extism/extism",
-  "version": "1.0.0-rc1",
+  "version": "0.0.1-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@extism/extism",
-      "version": "1.0.0-rc1",
+      "version": "0.0.1-rc1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.2.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extism/extism",
-  "version": "1.0.0-rc1",
+  "version": "0.0.1-rc1",
   "description": "Extism runtime for JavaScript",
   "scripts": {
     "build": "node build.js && tsc --emitDeclarationOnly --project ./tsconfig.node.json --declaration --outDir dist && tsc --emitDeclarationOnly --project ./tsconfig.browser.json --declaration --outDir dist",


### PR DESCRIPTION
Fixes #12 

For Deno, we just need to submit the repo here: https://deno.com/add_module, I don't have the right permissions to do it

Note: the git tags must no longer have the `v` prefix, let me know if this is a deal breaker. Example: `1.0.0-rc2`