### PR TITLE
feat: accept WebAssembly.Module, Response inputs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "imports": {
     "js-sdk:worker-url": "./src/worker-url.ts",
+    "js-sdk:response-to-module": "./src/polyfills/response-to-module.ts",
     "js-sdk:minimatch": "./src/polyfills/deno-minimatch.ts",
     "js-sdk:capabilities": "./src/polyfills/deno-capabilities.ts",
     "js-sdk:wasi": "./src/polyfills/deno-wasi.ts",

--- a/justfile
+++ b/justfile
@@ -151,6 +151,7 @@ build_node_cjs out='cjs' args='[]':
         "minify": false,
         "alias": {
           "js-sdk:capabilities": "./src/polyfills/node-capabilities.ts",
+          "js-sdk:response-to-module": "./src/polyfills/response-to-module.ts",
           "js-sdk:minimatch": "./src/polyfills/node-minimatch.ts",
           "js-sdk:worker-url": "./dist/worker/node/worker-url.ts",
           "js-sdk:fs": "node:fs/promises",
@@ -182,6 +183,7 @@ build_node_esm out='esm' args='[]':
         "minify": false,
         "alias": {
           "js-sdk:capabilities": "./src/polyfills/node-capabilities.ts",
+          "js-sdk:response-to-module": "./src/polyfills/response-to-module.ts",
           "js-sdk:minimatch": "./src/polyfills/node-minimatch.ts",
           "js-sdk:worker-url": "./dist/worker/node/worker-url.ts",
           "js-sdk:fs": "node:fs/promises",
@@ -202,6 +204,7 @@ build_bun out='bun' args='[]':
         "minify": false,
         "alias": {
           "js-sdk:worker-url": "./src/polyfills/bun-worker-url.ts",
+          "js-sdk:response-to-module": "./src/polyfills/bun-response-to-module.ts",
           "js-sdk:minimatch": "./src/polyfills/node-minimatch.ts",
           "js-sdk:capabilities": "./src/polyfills/bun-capabilities.ts",
           "js-sdk:fs": "node:fs/promises",
@@ -222,6 +225,7 @@ build_browser out='browser' args='[]':
         "format": "esm",
         "alias": {
           "js-sdk:capabilities": "./src/polyfills/browser-capabilities.ts",
+          "js-sdk:response-to-module": "./src/polyfills/response-to-module.ts",
           "js-sdk:minimatch": "./src/polyfills/node-minimatch.ts",
           "node:worker_threads": "./src/polyfills/host-node-worker_threads.ts",
           "js-sdk:fs": "./src/polyfills/browser-fs.ts",

--- a/src/background-plugin.ts
+++ b/src/background-plugin.ts
@@ -349,7 +349,7 @@ class HttpContext {
 export async function createBackgroundPlugin(
   opts: InternalConfig,
   names: string[],
-  modules: ArrayBuffer[],
+  modules: WebAssembly.Module[],
 ): Promise<BackgroundPlugin> {
   const worker = new Worker(WORKER_URL);
   const context = new CallContext(SharedArrayBuffer, opts.logger, opts.config);
@@ -394,7 +394,7 @@ export async function createBackgroundPlugin(
     });
   });
 
-  worker.postMessage(message, modules);
+  worker.postMessage(message);
   await onready;
 
   return new BackgroundPlugin(worker, sharedData, opts, context);

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -2,7 +2,7 @@ import { CAPABILITIES } from 'js-sdk:capabilities';
 
 import type { ManifestLike, InternalConfig, ExtismPluginOptions, Plugin } from './interfaces.ts';
 
-import { intoManifest as _intoManifest, toWasmModuleData as _toWasmModuleData } from './manifest.ts';
+import { toWasmModuleData as _toWasmModuleData } from './manifest.ts';
 
 import { createForegroundPlugin as _createForegroundPlugin } from './foreground-plugin.ts';
 import { createBackgroundPlugin as _createBackgroundPlugin } from './background-plugin.ts';
@@ -13,6 +13,8 @@ export type {
   Capabilities,
   ExtismPluginOptions,
   ManifestLike,
+  ManifestWasmResponse,
+  ManifestWasmModule,
   ManifestWasmData,
   ManifestWasmUrl,
   ManifestWasmPath,
@@ -64,7 +66,6 @@ export async function createPlugin(
   manifest: ManifestLike | PromiseLike<ManifestLike>,
   opts: ExtismPluginOptions = {},
 ): Promise<Plugin> {
-  manifest = await _intoManifest(await Promise.resolve(manifest));
   opts = { ...opts };
   opts.useWasi ??= false;
   opts.functions = opts.functions || {};
@@ -72,6 +73,7 @@ export async function createPlugin(
   opts.allowedHosts ??= <any>[].concat(opts.allowedHosts || []);
   opts.logger ??= console;
   opts.config ??= {};
+  opts.fetch ??= fetch;
 
   opts.runInWorker ??= CAPABILITIES.hasWorkerCapability;
   if (opts.runInWorker && !CAPABILITIES.hasWorkerCapability) {
@@ -80,7 +82,7 @@ export async function createPlugin(
     );
   }
 
-  const [names, moduleData] = await _toWasmModuleData(manifest, opts.fetch ?? fetch);
+  const [names, moduleData] = await _toWasmModuleData(await Promise.resolve(manifest), opts.fetch ?? fetch);
 
   const ic: InternalConfig = {
     allowedHosts: opts.allowedHosts as [],

--- a/src/polyfills/bun-response-to-module.ts
+++ b/src/polyfills/bun-response-to-module.ts
@@ -1,0 +1,23 @@
+// XXX(chrisdickinson): BUN NOTE: bun doesn't support `WebAssembly.compileStreaming` at the time of writing, nor
+// does cloning a response work [1].
+//
+// [1]: https://github.com/oven-sh/bun/issues/6348
+export async function responseToModule(
+  response: Response,
+  _hasHash?: boolean,
+): Promise<{ module: WebAssembly.Module; data?: ArrayBuffer }> {
+  if (String(response.headers.get('Content-Type')).split(';')[0] === 'application/octet-stream') {
+    const headers = new Headers(response.headers);
+    headers.set('Content-Type', 'application/wasm');
+
+    response = new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: headers,
+    });
+  }
+  const data = await response.arrayBuffer();
+  const module = await WebAssembly.compile(data);
+
+  return { module, data };
+}

--- a/src/polyfills/response-to-module.ts
+++ b/src/polyfills/response-to-module.ts
@@ -1,0 +1,26 @@
+export async function responseToModule(
+  response: Response,
+  hasHash?: boolean,
+): Promise<{ module: WebAssembly.Module; data?: ArrayBuffer }> {
+  if (String(response.headers.get('Content-Type')).split(';')[0] === 'application/octet-stream') {
+    const headers = new Headers(response.headers);
+    headers.set('Content-Type', 'application/wasm');
+
+    response = new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: headers,
+    });
+  }
+
+  // XXX(chrisdickinson): Note that we want to pass a `Response` to WebAssembly.compileStreaming if we
+  // can to play nicely with V8's code caching [1]. At the same time, we need the original ArrayBuffer data
+  // to verify any hashes. There's no way back to bytes from `WebAssembly.Module`, so we have to `.clone()`
+  // the response to get the `ArrayBuffer` data if we need to check a hash.
+  //
+  // [1]: https://v8.dev/blog/wasm-code-caching#algorithm
+  const data = hasHash ? await response.clone().arrayBuffer() : undefined;
+  const module = await WebAssembly.compileStreaming(response);
+
+  return { module, data };
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -122,7 +122,7 @@ class Reactor {
     ev: InternalConfig & {
       type: string;
       names: string[];
-      modules: ArrayBuffer[];
+      modules: WebAssembly.Module[];
       sharedData: SharedArrayBuffer;
       functions: { [name: string]: string[] };
     },

--- a/types/js-sdk/index.d.ts
+++ b/types/js-sdk/index.d.ts
@@ -1,3 +1,7 @@
+declare module 'js-sdk:response-to-module' {
+  export function responseToModule(response: Response, hasHash?: boolean): Promise<{module: WebAssembly.Module, data?: ArrayBuffer}>; 
+}
+
 declare module 'js-sdk:capabilities' {
   import type { Capabilities } from '../../src/interfaces';
 


### PR DESCRIPTION
`createPlugin` now accepts two additional manifest types (`response` and `module`) as well as `Response` and `WebAssembly.Module`. There are four goals here:

1. Allow us to target the Cloudflare Workers platform. CF Workers only support loading Wasm via `import` statements; these resolve to `WebAssembly.Module` objects, which means we need to allow users to pass `Module`s in addition to our other types.
2. Play nicely with V8's [Wasm caching][1]; in particular V8 will use metadata from the `Response` to build a key for caching the results of Wasm compilation.
3. This sets us up to implement [Wasm linking][2] by allowing us to introspect plugin modules imports and exports before instantiation.
4. And finally, resolving to modules instead of arraybuffers allows us to add [hooks for observe-sdk][3] (especially in advance of adding [thread pooling][4]).

Because Bun lacks support for `WebAssembly.compileStreaming` and `Response.clone()`, we provide an alternate implementation for converting a response to a module and its metadata.

One caveat is that there's no way to get the source bytes of a `WebAssembly.Module`, so `{module}` cannot be used with `{hash}` in a `Manifest`.

Fixes https://github.com/extism/js-sdk/issues/9

[1]: https://v8.dev/blog/wasm-code-caching#stream
[2]: https://github.com/extism/js-sdk/issues/29
[3]: https://github.com/extism/js-sdk/issues/3
[4]: https://github.com/extism/js-sdk/issues/31