### PR TITLE
fix: check manifest candidate type against Response

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -31,7 +31,7 @@ async function _populateWasmField(candidate: ManifestLike, _fetch: typeof fetch)
     candidate = new URL(candidate);
   }
 
-  if (candidate?.constructor?.name === 'Response') {
+  if (candidate instanceof Response || candidate?.constructor?.name === 'Response') {
     const response: Response = candidate as Response;
     const contentType = response.headers.get('content-type') || 'application/octet-stream';
 


### PR DESCRIPTION
Fix a regression on node v18.18.2 and v21.0.0 introduced by 630fcd6.

In particular, in v18.18.2 and v21.0.0, the Response constructor's name property is `_Response`, not `Response`. I originally added the stringly-typed check to allow for alternative `fetch()` implementations, so I've retained the string check but now additionally check to see whether the candidate is `instanceof Response`.

Fixes https://github.com/extism/js-sdk/issues/33