### PR TITLE
fix: add PluginOutput#text(); alias #string(); incl in docs

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,11 @@ export class PluginOutput extends DataView {
     return this.buffer;
   }
 
+  text(): string {
+    return this.string()
+  }
+
+  /** @hidden */
   string(): string {
     return PluginOutput.#decoder.decode(this.buffer);
   }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -21,6 +21,7 @@ export type {
   ManifestWasm,
   Manifest,
   Plugin,
+  PluginOutput,
 } from './interfaces.ts';
 
 export type { CallContext, CallContext as CurrentPlugin } from './call-context.ts';


### PR DESCRIPTION
I flubbed naming the string output function: it should be `.text()` in order to align with the Web Platform `Response` type, but for some reason, I called it `.string()` instead. This corrects that error, while preserving the `.string()` method as a hidden item so it's not a breaking change.

Additionally, export the `PluginOutput` type so it's visible in typedoc.

Closes #35