### PR TITLE
fix: use globalThis in place of window

### DIFF
--- a/justfile
+++ b/justfile
@@ -221,7 +221,7 @@ build_browser out='browser' args='[]':
       [{
         "entryPoints": ["src/mod.ts"],
         "platform": "browser",
-        "define": {"global": "window"},
+        "define": {"global": "globalThis"},
         "format": "esm",
         "alias": {
           "js-sdk:capabilities": "./src/polyfills/browser-capabilities.ts",

--- a/src/polyfills/browser-capabilities.ts
+++ b/src/polyfills/browser-capabilities.ts
@@ -14,8 +14,8 @@ export const CAPABILITIES: Capabilities = {
   fsAccess: false,
 
   hasWorkerCapability:
-    typeof window !== 'undefined'
-      ? (window as any).crossOriginIsolated && typeof SharedArrayBuffer !== 'undefined'
+    typeof globalThis !== 'undefined'
+      ? (globalThis as any).crossOriginIsolated && typeof SharedArrayBuffer !== 'undefined'
       : true,
 
   supportsWasiPreview1: true,


### PR DESCRIPTION
Enables compat with Cloudflare Workers env: 

```typescript
import createPlugin from '@extism/extism';

export interface Env {}

import wasm from "./count_vowels.wasm";

export default {
	async fetch(request: Request, _env: Env, _ctx: ExecutionContext): Promise<Response> {
		const plugin = await createPlugin(wasm, { useWasi: false });

		let out = await plugin.call("count_vowels", await request.text());
		return Response.json(out!.json())
	},
};
```

wrangler.toml: 

```toml
name = "cf-host"
main = "src/worker.ts"
compatibility_date = "2023-12-06"

rules = [{ type = "CompiledWasm", globs = ["**/*.wasm"], fallthrough = true }]
```