### PR TITLE
fix: mark threads as experimental

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -135,7 +135,11 @@ export interface ExtismPluginOptions {
   /**
    * Whether or not to run the Wasm module in a Worker thread. Requires
    * {@link Capabilities#hasWorkerCapability | `CAPABILITIES.hasWorkerCapability`} to
-   * be true.
+   * be true. Defaults to false.
+   *
+   * This feature is marked experimental as we work out [a bug](https://github.com/extism/js-sdk/issues/46).
+   *
+   * @experimental
    */
   runInWorker?: boolean;
 
@@ -190,6 +194,7 @@ export interface InternalConfig {
 export interface InternalWasi {
   importObject(): Promise<Record<string, WebAssembly.ImportValue>>;
   initialize(instance: WebAssembly.Instance): Promise<void>;
+  close(): Promise<void>;
 }
 
 /**

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -77,7 +77,8 @@ export async function createPlugin(
   opts.config ??= {};
   opts.fetch ??= fetch;
 
-  opts.runInWorker ??= CAPABILITIES.hasWorkerCapability;
+  // TODO(chrisdickinson): reset this to `CAPABILITIES.hasWorkerCapability` once we've fixed https://github.com/extism/js-sdk/issues/46.
+  opts.runInWorker ??= false;
   if (opts.runInWorker && !CAPABILITIES.hasWorkerCapability) {
     throw new Error(
       'Cannot enable off-thread wasm; current context is not `crossOriginIsolated` (see https://mdn.io/crossOriginIsolated)',

--- a/src/polyfills/browser-wasi.ts
+++ b/src/polyfills/browser-wasi.ts
@@ -49,6 +49,10 @@ export async function loadWasi(
       return context.wasiImport;
     },
 
+    async close() {
+      // noop
+    },
+
     async initialize(instance: WebAssembly.Instance) {
       const memory = instance.exports.memory as WebAssembly.Memory;
 


### PR DESCRIPTION
Because we're still working out kinks in the implementation [1], users can specifically request that plugins run in the background, but they no longer do so by default where available. Once [1] is fixed, we're likely to make threading default again.

[1]: https://github.com/extism/js-sdk/issues/46