### PR TITLE
doc: add note about ref docs and manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const plugin = await createPlugin(
 );
 ```
 
-> *Note*: Plug-ins can be loaded in a variety of ways, see the reference docs for [createPlugin](https://extism.github.io/js-sdk/functions/createPlugin.html)
+> *Note*: Plug-ins can be loaded in a variety of ways. See the reference docs for [createPlugin](https://extism.github.io/js-sdk/functions/createPlugin.html)
 > and read about the [manifest](https://extism.org/docs/concepts/manifest/).
 
 ## Calling A Plug-in's Exports

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ const plugin = await createPlugin(
 );
 ```
 
+> *Note*: Plug-ins can be loaded in a variety of ways, see the reference docs for [createPlugin](https://extism.github.io/js-sdk/functions/createPlugin.html)
+> and read about the [manifest](https://extism.org/docs/concepts/manifest/).
+
 ## Calling A Plug-in's Exports
 
 We're using a plug-in, `count_vowels`, which was compiled from Rust.


### PR DESCRIPTION
Where possible we should be linking off the ref docs in places like this to train people how to read them