### PR TITLE
Add 'fileDescriptors' option to allow file I/O to be used in the browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-replaced-by-ci",
       "license": "BSD-3-Clause",
       "devDependencies": {
-        "@bjorn3/browser_wasi_shim": "^0.2.17",
+        "@bjorn3/browser_wasi_shim": "^0.2.20",
         "@playwright/test": "^1.39.0",
         "@types/node": "^20.8.7",
         "@typescript-eslint/eslint-plugin": "^6.8.0",
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@bjorn3/browser_wasi_shim": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.17.tgz",
-      "integrity": "sha512-B2qcaGROo4e2s4nXb3VPATrczVrntM4BUXtAU1gEzUOfqKTcVuePq4NfhH5hmLBSvZ45YcT4gflDRUFYqLhkxA==",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.20.tgz",
+      "integrity": "sha512-URvkOAWWRQ8gazkBRgQ/e0H6R0VlOALJ9/vI2VBttG23MHzUZzy5KFyKAFVI1qL/hbqLwnZw/sIXFkeS6OH5EQ==",
       "dev": true
     },
     "node_modules/@esbuild/android-arm": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "author": "The Extism Authors <oss@extism.org>",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "@bjorn3/browser_wasi_shim": "^0.2.17",
+    "@bjorn3/browser_wasi_shim": "^0.2.20",
     "@playwright/test": "^1.39.0",
     "@types/node": "^20.8.7",
     "@typescript-eslint/eslint-plugin": "^6.8.0",

--- a/src/foreground-plugin.ts
+++ b/src/foreground-plugin.ts
@@ -156,7 +156,7 @@ async function instantiateModule(
         }
 
         if (wasi === null) {
-          wasi = await loadWasi(opts.allowedPaths, opts.enableWasiOutput);
+          wasi = await loadWasi(opts.allowedPaths, opts.enableWasiOutput, opts.fileDescriptors);
           wasiList.push(wasi);
           imports.wasi_snapshot_preview1 = await wasi.importObject();
         }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,5 @@
+import { Fd } from '@bjorn3/browser_wasi_shim';
+
 import { CallContext } from './call-context.ts';
 
 /**
@@ -167,6 +169,7 @@ export interface ExtismPluginOptions {
   functions?: { [key: string]: { [key: string]: (callContext: CallContext, ...args: any[]) => any } } | undefined;
   allowedPaths?: { [key: string]: string } | undefined;
   allowedHosts?: string[] | undefined;
+  fileDescriptors?: Fd[];
 
   /**
    * Whether WASI stdout should be forwarded to the host.
@@ -189,6 +192,7 @@ export interface InternalConfig {
   wasiEnabled: boolean;
   config: PluginConfig;
   sharedArrayBufferSize: number;
+  fileDescriptors: Fd[];
 }
 
 export interface InternalWasi {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -99,6 +99,7 @@ export async function createPlugin(
     config: opts.config,
     enableWasiOutput: opts.enableWasiOutput,
     sharedArrayBufferSize: Number(opts.sharedArrayBufferSize) || 1 << 16,
+    fileDescriptors: opts.fileDescriptors ?? [],
   };
 
   return (opts.runInWorker ? _createBackgroundPlugin : _createForegroundPlugin)(ic, names, moduleData);

--- a/src/polyfills/browser-wasi.ts
+++ b/src/polyfills/browser-wasi.ts
@@ -66,5 +66,3 @@ export async function loadWasi(
     },
   };
 }
-
-// trivial change to trigger workflow

--- a/src/polyfills/browser-wasi.ts
+++ b/src/polyfills/browser-wasi.ts
@@ -66,3 +66,5 @@ export async function loadWasi(
     },
   };
 }
+
+// trivial change to trigger workflow

--- a/src/polyfills/deno-wasi.ts
+++ b/src/polyfills/deno-wasi.ts
@@ -1,3 +1,4 @@
+import { Fd } from '@bjorn3/browser_wasi_shim';
 import Context from 'https://deno.land/std@0.200.0/wasi/snapshot_preview1.ts';
 import { type InternalWasi } from '../interfaces.ts';
 import { devNull } from 'node:os';
@@ -29,6 +30,8 @@ async function createDevNullFDs() {
 export async function loadWasi(
   allowedPaths: { [from: string]: string },
   enableWasiOutput: boolean,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  fileDescriptors: Fd[],
 ): Promise<InternalWasi> {
   const {
     close,

--- a/src/polyfills/node-wasi.ts
+++ b/src/polyfills/node-wasi.ts
@@ -1,3 +1,4 @@
+import { Fd } from '@bjorn3/browser_wasi_shim';
 import { WASI } from 'wasi';
 import { type InternalWasi } from '../interfaces.ts';
 import { devNull } from 'node:os';
@@ -39,6 +40,8 @@ async function createDevNullFDs() {
 export async function loadWasi(
   allowedPaths: { [from: string]: string },
   enableWasiOutput: boolean,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  fileDescriptors: Fd[],
 ): Promise<InternalWasi> {
   const {
     close,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,11 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "esnext",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
     "declaration": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This option is only used by wasi-browser.ts.  It doesn't really make sense for node/deno/bun since those runtimes have native support for WASI.

I'm having issues running the tests so I haven't bothered trying to enable `fileAccess` for the browser tests.

I have done some manual testing to verify that things are working as expected.  I have a plugin with the following F# cord:
```fs
[<UnmanagedCallersOnly(EntryPoint = "greet")>]
let Greet () : int32 =
    printfn "Greet called"

    let contents = File.ReadAllText("./input.txt")
    printfn "contents = %s" contents
    
    let input = Pdk.GetInputString()
    printfn $"input = {input}"
    let data = JsonSerializer.Deserialize<Data> input
    
    printfn $"greeting = {data.greeting}, name = {data.name}"
    
    let result = $"{data.greeting}, {data.name}!"
    Pdk.SetOutput(result)
    0
```

The JavaScript host code looks like this (note, this requires input.txt to exist in the directory being served):
```js
import createPlugin from '@extism/extism';
import { WASI, File, OpenFile, ConsoleStdout, PreopenDirectory } from "@bjorn3/browser_wasi_shim";

const input = await fetch(`/input.txt`);
const inputBuffer = await input.arrayBuffer();

const url = new URL(`${location.protocol}/${location.host}/Plugin/bin/Debug/net8.0/wasi-wasm/AppBundle/Plugin.wasm`);
const options = { 
    useWasi: true, 
    enableWasiOutput: true,
    fileDescriptors: [
        new PreopenDirectory(".", {
            "input.txt": new File(inputBuffer),
        }),
    ]
};
const plugin = await createPlugin(url, options);

const input = JSON.stringify({ greeting: "hello", name: "world" });
const out = await plugin.call("greet", input);
console.log(out.text());
```

The output in the browser console looks like this:
```
Greet called
contents = This is a text file
input = {"greeting":"hello","name":"world"}
greeting = hello, name = world
hello, world!
```