### PR TITLE
use correct version of jsr module

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const createPlugin = require("@extism/extism")
 import createPlugin from '@extism/extism';
 
 // Deno
-import createPlugin from "jsr:@extism/extism";
+import createPlugin from "jsr:@extism/extism@2.0.0-rc1";
 ```
 
 ## Creating A Plug-in


### PR DESCRIPTION
because there is no stable release yet, importing from "@extism/extism" without the version will error

```
error: Could not find constraint in the list of versions: @extism/extism
  Specifier: jsr:@extism/extism
```