### PR TITLE
Allow browsers to specify fd preopens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-replaced-by-ci",
       "license": "BSD-3-Clause",
       "devDependencies": {
-        "@bjorn3/browser_wasi_shim": "^0.2.17",
+        "@bjorn3/browser_wasi_shim": "^0.2.20",
         "@playwright/test": "^1.39.0",
         "@types/node": "^20.8.7",
         "@typescript-eslint/eslint-plugin": "^6.8.0",
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@bjorn3/browser_wasi_shim": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.17.tgz",
-      "integrity": "sha512-B2qcaGROo4e2s4nXb3VPATrczVrntM4BUXtAU1gEzUOfqKTcVuePq4NfhH5hmLBSvZ45YcT4gflDRUFYqLhkxA==",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.20.tgz",
+      "integrity": "sha512-URvkOAWWRQ8gazkBRgQ/e0H6R0VlOALJ9/vI2VBttG23MHzUZzy5KFyKAFVI1qL/hbqLwnZw/sIXFkeS6OH5EQ==",
       "dev": true
     },
     "node_modules/@esbuild/android-arm": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "author": "The Extism Authors <oss@extism.org>",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "@bjorn3/browser_wasi_shim": "^0.2.17",
+    "@bjorn3/browser_wasi_shim": "^0.2.20",
     "@playwright/test": "^1.39.0",
     "@types/node": "^20.8.7",
     "@typescript-eslint/eslint-plugin": "^6.8.0",

--- a/src/foreground-plugin.ts
+++ b/src/foreground-plugin.ts
@@ -156,7 +156,7 @@ async function instantiateModule(
         }
 
         if (wasi === null) {
-          wasi = await loadWasi(opts.allowedPaths, opts.enableWasiOutput);
+          wasi = await loadWasi(opts.allowedPaths, opts.enableWasiOutput, opts.fileDescriptors);
           wasiList.push(wasi);
           imports.wasi_snapshot_preview1 = await wasi.importObject();
         }

--- a/src/foreground-plugin.ts
+++ b/src/foreground-plugin.ts
@@ -156,7 +156,7 @@ async function instantiateModule(
         }
 
         if (wasi === null) {
-          wasi = await loadWasi(opts.allowedPaths, opts.enableWasiOutput, opts.fileDescriptors);
+          wasi = await loadWasi(opts.allowedPaths, opts.enableWasiOutput, opts.wasiOptions);
           wasiList.push(wasi);
           imports.wasi_snapshot_preview1 = await wasi.importObject();
         }
@@ -211,9 +211,9 @@ async function instantiateModule(
       const instance = providerExports.find((xs) => xs.name === '_start')
         ? await instantiateModule([...current, module], provider, imports, opts, wasiList, names, modules, new Map())
         : !linked.has(provider)
-        ? (await instantiateModule([...current, module], provider, imports, opts, wasiList, names, modules, linked),
-          linked.get(provider))
-        : linked.get(provider);
+          ? (await instantiateModule([...current, module], provider, imports, opts, wasiList, names, modules, linked),
+            linked.get(provider))
+          : linked.get(provider);
 
       if (!instance) {
         // circular import, either make a trampoline or bail
@@ -254,10 +254,10 @@ async function instantiateModule(
   const guestType = instance.exports.hs_init
     ? 'haskell'
     : instance.exports._initialize
-    ? 'reactor'
-    : instance.exports._start
-    ? 'command'
-    : 'none';
+      ? 'reactor'
+      : instance.exports._start
+        ? 'command'
+        : 'none';
 
   if (wasi) {
     await wasi?.initialize(instance);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -124,6 +124,19 @@ export interface Plugin {
 }
 
 /**
+ * Options for initializing WASI.
+ */
+export interface WASIOptions {
+  /**
+   * A list of file descriptors; only available in browser environments.
+   *
+   * See [`@bjorn3/browser_wasi_shim`](https://github.com/bjorn3/browser_wasi_shim) for more
+   * details on use.
+   */
+  fileDescriptors: (import('@bjorn3/browser_wasi_shim').Fd)[];
+}
+
+/**
  * Options for initializing an Extism plugin.
  */
 export interface ExtismPluginOptions {
@@ -167,6 +180,7 @@ export interface ExtismPluginOptions {
   functions?: { [key: string]: { [key: string]: (callContext: CallContext, ...args: any[]) => any } } | undefined;
   allowedPaths?: { [key: string]: string } | undefined;
   allowedHosts?: string[] | undefined;
+  wasiOptions?: WasiOptions;
 
   /**
    * Whether WASI stdout should be forwarded to the host.
@@ -189,6 +203,7 @@ export interface InternalConfig {
   wasiEnabled: boolean;
   config: PluginConfig;
   sharedArrayBufferSize: number;
+  wasiOptions: WasiOptions | null;
 }
 
 export interface InternalWasi {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -133,7 +133,7 @@ export interface WASIOptions {
    * See [`@bjorn3/browser_wasi_shim`](https://github.com/bjorn3/browser_wasi_shim) for more
    * details on use.
    */
-  fileDescriptors: (import('@bjorn3/browser_wasi_shim').Fd)[];
+  fileDescriptors: any[];
 }
 
 /**
@@ -180,7 +180,7 @@ export interface ExtismPluginOptions {
   functions?: { [key: string]: { [key: string]: (callContext: CallContext, ...args: any[]) => any } } | undefined;
   allowedPaths?: { [key: string]: string } | undefined;
   allowedHosts?: string[] | undefined;
-  wasiOptions?: WasiOptions;
+  wasiOptions?: WASIOptions;
 
   /**
    * Whether WASI stdout should be forwarded to the host.
@@ -203,7 +203,7 @@ export interface InternalConfig {
   wasiEnabled: boolean;
   config: PluginConfig;
   sharedArrayBufferSize: number;
-  wasiOptions: WasiOptions | null;
+  wasiOptions: WASIOptions | null;
 }
 
 export interface InternalWasi {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -99,6 +99,7 @@ export async function createPlugin(
     config: opts.config,
     enableWasiOutput: opts.enableWasiOutput,
     sharedArrayBufferSize: Number(opts.sharedArrayBufferSize) || 1 << 16,
+    fileDescriptors: opts.fileDescriptors ?? [],
   };
 
   return (opts.runInWorker ? _createBackgroundPlugin : _createForegroundPlugin)(ic, names, moduleData);

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -99,7 +99,7 @@ export async function createPlugin(
     config: opts.config,
     enableWasiOutput: opts.enableWasiOutput,
     sharedArrayBufferSize: Number(opts.sharedArrayBufferSize) || 1 << 16,
-    fileDescriptors: opts.fileDescriptors ?? [],
+    wasiOptions: opts.wasiOptions ?? null,
   };
 
   return (opts.runInWorker ? _createBackgroundPlugin : _createForegroundPlugin)(ic, names, moduleData);

--- a/src/polyfills/browser-wasi.ts
+++ b/src/polyfills/browser-wasi.ts
@@ -1,27 +1,27 @@
 import { WASI, Fd, File, OpenFile, ConsoleStdout } from '@bjorn3/browser_wasi_shim';
-import { type InternalWasi } from '../interfaces.ts';
+import { type WASIOptions, type InternalWasi } from '../interfaces.ts';
 
 export async function loadWasi(
   _allowedPaths: { [from: string]: string },
   enableWasiOutput: boolean,
-  fileDescriptors: Fd[],
+  wasiOptions: WASIOptions | null
 ): Promise<InternalWasi> {
-  console.log('fileDescriptors = ', fileDescriptors);
   const args: Array<string> = [];
   const envVars: Array<string> = [];
+  const fileDescriptors = (wasiOptions?.fileDescriptors || []) as Fd[]
   const fds: Fd[] = enableWasiOutput
     ? [
-        ConsoleStdout.lineBuffered((msg) => console.log(msg)), // fd 0 is dup'd to stdout
-        ConsoleStdout.lineBuffered((msg) => console.log(msg)),
-        ConsoleStdout.lineBuffered((msg) => console.warn(msg)),
-        ...fileDescriptors,
-      ]
+      ConsoleStdout.lineBuffered((msg) => console.log(msg)), // fd 0 is dup'd to stdout
+      ConsoleStdout.lineBuffered((msg) => console.log(msg)),
+      ConsoleStdout.lineBuffered((msg) => console.warn(msg)),
+      ...fileDescriptors,
+    ]
     : [
-        new OpenFile(new File([])), // stdin
-        new OpenFile(new File([])), // stdout
-        new OpenFile(new File([])), // stderr
-        ...fileDescriptors,
-      ];
+      new OpenFile(new File([])), // stdin
+      new OpenFile(new File([])), // stdout
+      new OpenFile(new File([])), // stderr
+      ...fileDescriptors,
+    ];
 
   const context = new WASI(args, envVars, fds, { debug: false });
 
@@ -59,7 +59,7 @@ export async function loadWasi(
         context.start({
           exports: {
             memory,
-            _start: () => {},
+            _start: () => { },
           },
         });
       }

--- a/src/polyfills/deno-wasi.ts
+++ b/src/polyfills/deno-wasi.ts
@@ -20,7 +20,7 @@ async function createDevNullFDs() {
   return {
     async close() {
       needsClose = false;
-      await Promise.all([stdin.close(), stdout.close()]).catch(() => {});
+      await Promise.all([stdin.close(), stdout.close()]).catch(() => { });
     },
     fds: [stdin.fd, stdout.fd, stdout.fd],
   };
@@ -29,11 +29,13 @@ async function createDevNullFDs() {
 export async function loadWasi(
   allowedPaths: { [from: string]: string },
   enableWasiOutput: boolean,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  fileDescriptors: Fd[],
 ): Promise<InternalWasi> {
   const {
     close,
     fds: [stdin, stdout, stderr],
-  } = enableWasiOutput ? { async close() {}, fds: [0, 1, 2] } : await createDevNullFDs();
+  } = enableWasiOutput ? { async close() { }, fds: [0, 1, 2] } : await createDevNullFDs();
   const context = new Context({
     preopens: allowedPaths,
     exitOnReturn: false,
@@ -76,7 +78,7 @@ export async function loadWasi(
         context.start({
           exports: {
             memory,
-            _start: () => {},
+            _start: () => { },
           },
         });
       }

--- a/src/polyfills/deno-wasi.ts
+++ b/src/polyfills/deno-wasi.ts
@@ -1,5 +1,5 @@
 import Context from './deno-snapshot_preview1.ts';
-import { type InternalWasi } from '../interfaces.ts';
+import { type WASIOptions, type InternalWasi } from '../interfaces.ts';
 import { devNull } from 'node:os';
 import { open } from 'node:fs/promises';
 import { closeSync } from 'node:fs';
@@ -29,8 +29,7 @@ async function createDevNullFDs() {
 export async function loadWasi(
   allowedPaths: { [from: string]: string },
   enableWasiOutput: boolean,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  fileDescriptors: Fd[],
+  _wasiOptions: WASIOptions | null,
 ): Promise<InternalWasi> {
   const {
     close,

--- a/src/polyfills/node-wasi.ts
+++ b/src/polyfills/node-wasi.ts
@@ -1,3 +1,4 @@
+import { Fd } from '@bjorn3/browser_wasi_shim';
 import { WASI } from 'wasi';
 import { type InternalWasi } from '../interfaces.ts';
 import { devNull } from 'node:os';
@@ -39,6 +40,8 @@ async function createDevNullFDs() {
 export async function loadWasi(
   allowedPaths: { [from: string]: string },
   enableWasiOutput: boolean,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  fileDescriptors: Fd[],
 ): Promise<InternalWasi> {
   const {
     close,

--- a/src/polyfills/node-wasi.ts
+++ b/src/polyfills/node-wasi.ts
@@ -1,6 +1,5 @@
-import { Fd } from '@bjorn3/browser_wasi_shim';
 import { WASI } from 'wasi';
-import { type InternalWasi } from '../interfaces.ts';
+import { type WASIOptions, type InternalWasi } from '../interfaces.ts';
 import { devNull } from 'node:os';
 import { open } from 'node:fs/promises';
 import { closeSync } from 'node:fs';
@@ -27,7 +26,7 @@ async function createDevNullFDs() {
     fr.register(stdout, stdout.fd);
     close = async () => {
       needsClose = false;
-      await Promise.all([stdin.close(), stdout.close()]).catch(() => {});
+      await Promise.all([stdin.close(), stdout.close()]).catch(() => { });
     };
   }
 
@@ -40,13 +39,12 @@ async function createDevNullFDs() {
 export async function loadWasi(
   allowedPaths: { [from: string]: string },
   enableWasiOutput: boolean,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  fileDescriptors: Fd[],
+  _wasiOptions: WASIOptions | null,
 ): Promise<InternalWasi> {
   const {
     close,
     fds: [stdin, stdout, stderr],
-  } = enableWasiOutput ? { async close() {}, fds: [0, 1, 2] } : await createDevNullFDs();
+  } = enableWasiOutput ? { async close() { }, fds: [0, 1, 2] } : await createDevNullFDs();
 
   const context = new WASI({
     version: 'preview1',
@@ -90,7 +88,7 @@ export async function loadWasi(
         context.start({
           exports: {
             memory,
-            _start: () => {},
+            _start: () => { },
           },
         });
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,11 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "esnext",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
     "declaration": true,
     "strict": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,9 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "esnext",
-    "moduleResolution": "Node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
-    "emitDeclarationOnly": true,
     "declaration": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
A continuation of #59.

Fd preopens are specific to `@bjorn3/browser_wasi_shim`. We expose an option to specify them in `src/interfaces.ts`, but the Fd type is specified as `any[]` because we can't directly reference that package from Deno/Node TS builds.

(This is a v2.0.0 release candidate feature.)