### PR TITLE
Allow allowedhosts only in background worker contexts

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -67,6 +67,7 @@
           useWasi: true,
           config: { thing: 'testing' },
           allowedHosts: [...hosts],
+          runInWorker: true,
         });
 
         const res = await plugin.call(funcname, new TextEncoder().encode(input));

--- a/examples/node.js
+++ b/examples/node.js
@@ -11,7 +11,8 @@ async function main() {
   const plugin = await createPlugin(filename, {
     useWasi: true,
     config: { thing: 'testing' },
-    withAllowedHosts: ['*.typicode.com'],
+    allowedHosts: ['*.typicode.com'],
+    runInWorker: true
   });
 
   const res = await plugin.call(funcname, new TextEncoder().encode(input));

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -166,6 +166,20 @@ export interface ExtismPluginOptions {
    */
   functions?: { [key: string]: { [key: string]: (callContext: CallContext, ...args: any[]) => any } } | undefined;
   allowedPaths?: { [key: string]: string } | undefined;
+
+  /**
+   * A list of allowed hostnames. Wildcard subdomains are supported via `*`.
+   *
+   * Requires the plugin to run in a worker using `runInWorker: true`.
+   *
+   * @example
+   * ```ts
+   * await createPlugin('path/to/some/wasm', {
+   *   runInWorker: true,
+   *   allowedHosts: ['*.example.com', 'www.dylibso.com']
+   * })
+   * ```
+   */
   allowedHosts?: string[] | undefined;
 
   /**

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -74,13 +74,17 @@ export async function createPlugin(
   opts.enableWasiOutput ??= opts.useWasi ? CAPABILITIES.extismStdoutEnvVarSet : false;
   opts.functions = opts.functions || {};
   opts.allowedPaths ??= {};
+  // TODO(chrisdickinson): reset this to `CAPABILITIES.hasWorkerCapability` once we've fixed https://github.com/extism/js-sdk/issues/46.
+  opts.runInWorker ??= false;
+  if (opts.allowedHosts && !opts.runInWorker) {
+    throw new TypeError('"allowedHosts" requires "runInWorker: true". HTTP functions are only available to plugins running in a worker.')
+  }
+
   opts.allowedHosts ??= <any>[].concat(opts.allowedHosts || []);
   opts.logger ??= console;
   opts.config ??= {};
   opts.fetch ??= fetch;
 
-  // TODO(chrisdickinson): reset this to `CAPABILITIES.hasWorkerCapability` once we've fixed https://github.com/extism/js-sdk/issues/46.
-  opts.runInWorker ??= false;
   if (opts.runInWorker && !CAPABILITIES.hasWorkerCapability) {
     throw new Error(
       'Cannot enable off-thread wasm; current context is not `crossOriginIsolated` (see https://mdn.io/crossOriginIsolated)',


### PR DESCRIPTION
Extism HTTP host functions are only available when running the plugin in the background on a worker; throw an error when attempting to specify allowedHosts on a foreground worker.

Fixes #56.