### PR TITLE
fix: remove user-agent from manifest requests

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -105,7 +105,6 @@ export async function toWasmModuleData(
         const response = await _fetch((item as ManifestWasmUrl).url, {
           headers: {
             accept: 'application/wasm;q=0.9,application/octet-stream;q=0.8',
-            'user-agent': 'extism',
           },
         });
         const result = await responseToModule(response, Boolean(item.hash));


### PR DESCRIPTION
This seems a bit like bad manners, but it's probably the most expedient route to fix issues like https://github.com/extism/playground/pull/27.