### PR TITLE
feat: add host context support

### DIFF
--- a/src/background-plugin.ts
+++ b/src/background-plugin.ts
@@ -1,5 +1,5 @@
 /*eslint-disable no-empty*/
-import { CallContext, RESET, IMPORT_STATE, EXPORT_STATE, STORE, GET_BLOCK, ENV } from './call-context.ts';
+import { CallContext, RESET, IMPORT_STATE, EXPORT_STATE, STORE, GET_BLOCK, ENV, SET_HOST_CONTEXT } from './call-context.ts';
 import { MemoryOptions, PluginOutput, SAB_BASE_OFFSET, SharedArrayBufferSection, type InternalConfig } from './interfaces.ts';
 import { readBodyUpTo } from './utils.ts';
 import { WORKER_URL } from './worker-url.ts';
@@ -167,8 +167,9 @@ class BackgroundPlugin {
   }
 
   // host -> guest invoke()
-  async call(funcName: string, input?: string | Uint8Array): Promise<PluginOutput | null> {
+  async call<T = any>(funcName: string, input?: string | Uint8Array, hostContext?: T): Promise<PluginOutput | null> {
     const index = this.#context[STORE](input);
+    this.#context[SET_HOST_CONTEXT](hostContext);
 
     const [errorIdx, outputIdx] = await this.callBlock(funcName, index);
 

--- a/src/foreground-plugin.ts
+++ b/src/foreground-plugin.ts
@@ -1,4 +1,4 @@
-import { CallContext, RESET, GET_BLOCK, BEGIN, END, ENV, STORE } from './call-context.ts';
+import { CallContext, RESET, GET_BLOCK, BEGIN, END, ENV, STORE, SET_HOST_CONTEXT } from './call-context.ts';
 import { PluginOutput, type InternalConfig, InternalWasi } from './interfaces.ts';
 import { loadWasi } from './polyfills/deno-wasi.ts';
 
@@ -61,8 +61,9 @@ export class ForegroundPlugin {
     }
   }
 
-  async call(funcName: string, input?: string | Uint8Array): Promise<PluginOutput | null> {
+  async call<T = any>(funcName: string, input?: string | Uint8Array, hostContext?: T): Promise<PluginOutput | null> {
     const inputIdx = this.#context[STORE](input);
+    this.#context[SET_HOST_CONTEXT](hostContext);
 
     const [errorIdx, outputIdx] = await this.callBlock(funcName, inputIdx);
     const shouldThrow = errorIdx !== null;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -103,9 +103,10 @@ export interface Plugin {
    *
    * @param {string} funcName The name of the function to call
    * @param {Uint8Array | string} input The input to pass to the function
+   * @param {T} hostContext Per-call context to make available to host functions
    * @returns {Promise<PluginOutput | null>} The result from the function call
    */
-  call(funcName: string, input?: string | number | Uint8Array): Promise<PluginOutput | null>;
+  call<T>(funcName: string, input?: string | number | Uint8Array, hostContext?: T): Promise<PluginOutput | null>;
   getExports(): Promise<WebAssembly.ModuleExportDescriptor[]>;
   getImports(): Promise<WebAssembly.ModuleImportDescriptor[]>;
   getInstance(): Promise<WebAssembly.Instance>;


### PR DESCRIPTION
This allows the host to communicate information with host functions without exposing the information to the guest plugin, porting behavior from extism/extism.