### PR TITLE
throw when allowed paths are prefixed with ro:

### DIFF
--- a/src/mod.test.ts
+++ b/src/mod.test.ts
@@ -821,6 +821,21 @@ if (typeof WebAssembly === 'undefined') {
   }
 
   if (CAPABILITIES.fsAccess && CAPABILITIES.supportsWasiPreview1) {
+    test('readonly allowed paths are not supported', async () => {
+      try {
+        await createPlugin(
+          { wasm: [{ name: 'main', url: 'http://localhost:8124/wasm/fs.wasm' }], allowedPaths: { '/mnt': 'ro:tests/data' } },
+          { useWasi: true, functions: {}, runInWorker: true },
+        );
+
+        assert.fail('should not reach here');
+      } catch (err) {
+        if (err instanceof Error) {
+          assert.equal(err.message, 'Readonly dirs are not supported: ro:tests/data');
+        }
+      }
+    });
+
     test('can access fs', async () => {
       const plugin = await createPlugin('http://localhost:8124/wasm/fs.wasm', {
         allowedPaths: { '/mnt': 'tests/data' },

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -96,6 +96,14 @@ export async function createPlugin(
   opts.allowedHosts = opts.allowedHosts || manifestOpts.allowedHosts || [];
   opts.config = opts.config || manifestOpts.config || {};
 
+  for (const guest in opts.allowedPaths) {
+    const host = opts.allowedPaths[guest];
+
+    if (host.startsWith('ro:')) {
+      throw new Error(`Readonly dirs are not supported: ${host}`)
+    }
+  }
+
   const ic: InternalConfig = {
     allowedHosts: opts.allowedHosts as [],
     allowedPaths: opts.allowedPaths,


### PR DESCRIPTION
Related to https://github.com/extism/extism/pull/733 and https://github.com/extism/go-sdk/pull/68

As far as I can see, we can't add readonly dirs support for the js-sdk


Note: I have noticed that the `allowedPaths` in the JS SDK is guest:host, while in the other sdks it's `host:guest`, we might need to make a breaking change in the js sdk to bring it in line with the other SDKs