### PR TITLE
fix: respect input offset and bytelength when storing data views

### DIFF
--- a/src/call-context.ts
+++ b/src/call-context.ts
@@ -496,7 +496,11 @@ export class CallContext {
     }
 
     if (input instanceof Uint8Array) {
-      if (input.buffer.constructor === this.#arrayBufferType) {
+      if (
+        input.buffer.constructor === this.#arrayBufferType &&
+        input.byteOffset === 0 &&
+        input.byteLength === input.buffer.byteLength
+      ) {
         // no action necessary, wrap it up in a block
         const idx = this.#blocks.length;
         this.#blocks.push(new Block(input.buffer, true));


### PR DESCRIPTION
If the incoming data view does not span the entire backing array buffer, copy the data into a smaller block.

Data views, like JS Typed Arrays (`Uint8Array` et al) and `DataView`, store a `byteOffset` and `byteLength` field which give them a window onto the bytes stored in an `ArrayBuffer`. We had been ignoring this when storing `Uint8Array` values -- we grabbed the backing buffer directly to store as a block.

In the future we could store that windowing data on the `Block` class, but that would be a more involved change for background thread contexts. We'd have to convey that windowing information down to the backing thread.

Fixes #81.