### PR TITLE
fix: include source map for worker.js on cjs/esm builds

### DIFF
--- a/justfile
+++ b/justfile
@@ -43,7 +43,6 @@ _build out args='[]': prepare
       const path = require("path");
 
       const args = [{
-          sourcemap: true,
           outdir: "dist/{{ out }}",
           bundle: true,
           minify: true,
@@ -60,6 +59,7 @@ _build out args='[]': prepare
         alias: combValue('alias'),
         polyfills: combValue('polyfills'),
         define: combValue('define'),
+        sourcemap: lastValue('sourcemap'),
       }
 
       const resolved = args.reduce((acc, xs) => {
@@ -95,7 +95,7 @@ _build out args='[]': prepare
 
             return { path: result, external: true }
           })
-        } 
+        }
       }];
 
 
@@ -125,6 +125,7 @@ build_worker out args='[]':
     #!/bin/bash
     config="$(<<<'{{ args }}' jq -cM '
       [{
+        "sourcemap": false,
         "entryPoints": ["src/worker.ts"],
         "bundle": true,
         "minify": true,
@@ -162,6 +163,7 @@ build_worker_browser out='worker/browser' args='[]':
     #!/bin/bash
     config="$(<<<'{{ args }}' jq -cM '
       [{
+        "sourcemap": true,
         "format": "esm",
         "alias": {
           "node:worker_threads": "./src/polyfills/worker-node-worker_threads.ts"
@@ -179,6 +181,7 @@ build_node_cjs out='cjs' args='[]':
     #!/bin/bash
     config="$(<<<'{{ args }}' jq -cM '
       [{
+        "sourcemap": true,
         "entryPoints": ["src/mod.ts"],
         "platform": "node",
         "minify": false,
@@ -209,6 +212,7 @@ build_node_esm out='esm' args='[]':
     #!/bin/bash
     config="$(<<<'{{ args }}' jq -cM '
       [{
+        "sourcemap": true,
         "entryPoints": ["src/mod.ts"],
         "platform": "node",
         "format": "esm",
@@ -229,6 +233,7 @@ build_bun out='bun' args='[]':
     #!/bin/bash
     config="$(<<<'{{ args }}' jq -cM '
       [{
+        "sourcemap": true,
         "entryPoints": ["src/mod.ts", "src/worker.ts"],
         "platform": "node",
         "format": "esm",
@@ -250,6 +255,7 @@ build_browser out='browser' args='[]':
     #!/bin/bash
     config="$(<<<'{{ args }}' jq -cM '
       [{
+        "sourcemap": true,
         "entryPoints": ["src/mod.ts"],
         "platform": "browser",
         "define": {"global": "globalThis"},

--- a/src/worker-url.ts
+++ b/src/worker-url.ts
@@ -1,5 +1,16 @@
-// This file is aliased by esbuild for commonjs, esm, and browser builds.
-const relativeUrl = (await import.meta.resolve('./worker.ts')) as string
+// NB(chris): we can't do the obvious thing here (`new URL('./worker.js', import.meta.url)`.)
+// Why? This file is consumed by Deno, and in Deno JSR packages `import.meta.url`
+// resolves to an `http(s):` protocol. However, `http(s):` protocol URLs are not supported
+// by node:worker_threads.
+//
+// (And oof, in order to switch from node workers to web Workers,
+// we'd have to polyfill the web Worker api on top of node. It was easier to go the other way
+// around.)
+//
+// In Node, Bun, and browser environments, this entire file is *ignored*: the esbuild config
+// replaces it with a prebuilt base64'd inline javascript URL. See `build_worker_node` in
+// the `justfile`.
+const relativeUrl = (await (import.meta.resolve as any)('./worker.ts')) as string
 export const WORKER_URL = `data:text/javascript;base64,${btoa(`
   export * from ${JSON.stringify(relativeUrl)};
 `)}`


### PR DESCRIPTION
Based on @thucpn's excellent work in #88.