### PR TITLE
cleanup: host takes ownership of memory blocks it gets as arguments

### DIFF
--- a/src/call-context.ts
+++ b/src/call-context.ts
@@ -309,6 +309,7 @@ export class CallContext {
       if (item === null) {
         return 0n;
       }
+      this.free(addr);
 
       const key = item.string();
       const result = this.getVariable(key);
@@ -323,6 +324,7 @@ export class CallContext {
         this.#logger.error(`attempted to set variable using invalid key address (addr="${addr.toString(16)}H")`);
         return;
       }
+      this.free(addr);
 
       const key = item.string();
 
@@ -349,6 +351,8 @@ export class CallContext {
         this.setError(err)
         return;
       }
+
+      this.free(valueaddr);
     },
 
     http_request: (_requestOffset: bigint, _bodyOffset: bigint): bigint => {
@@ -380,6 +384,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.warn(text);
+      this.free(addr);
     },
 
     log_info: (addr: bigint) => {
@@ -393,6 +398,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.info(text);
+      this.free(addr);
     },
 
     log_debug: (addr: bigint) => {
@@ -406,6 +412,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.debug(text);
+      this.free(addr);
     },
 
     log_error: (addr: bigint) => {
@@ -419,6 +426,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.error(text);
+      this.free(addr);
     },
   };
 

--- a/src/call-context.ts
+++ b/src/call-context.ts
@@ -296,7 +296,7 @@ export class CallContext {
 
       const key = item.string();
 
-      this.free(addr);
+      this[ENV].free(addr);
 
       if (key in this.#config) {
         return this.store(this.#config[key]);
@@ -313,7 +313,7 @@ export class CallContext {
       }
 
       const key = item.string();
-      this.free(addr);
+      this[ENV].free(addr);
 
       const result = this.getVariable(key);
       const stored = result ? this[STORE](result.bytes()) || 0 : 0;
@@ -329,7 +329,7 @@ export class CallContext {
       }
 
       const key = item.string();
-      this.free(addr);
+      this[ENV].free(addr);
 
       if (valueaddr === 0n) {
         this.deleteVariable(key)
@@ -349,7 +349,7 @@ export class CallContext {
         const copied = new Uint8Array(valueBlock.buffer.byteLength)
         copied.set(new Uint8Array(valueBlock.buffer), 0)
         this.setVariable(key, copied);
-        this.free(valueaddr);
+        this[ENV].free(valueaddr);
       } catch (err: any) {
         this.#logger.error(err.message)
         this.setError(err)
@@ -386,7 +386,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.warn(text);
-      this.free(addr);
+      this[ENV].free(addr);
     },
 
     log_info: (addr: bigint) => {
@@ -400,7 +400,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.info(text);
-      this.free(addr);
+      this[ENV].free(addr);
     },
 
     log_debug: (addr: bigint) => {
@@ -414,7 +414,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.debug(text);
-      this.free(addr);
+      this[ENV].free(addr);
     },
 
     log_error: (addr: bigint) => {
@@ -428,7 +428,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.error(text);
-      this.free(addr);
+      this[ENV].free(addr);
     },
   };
 

--- a/src/call-context.ts
+++ b/src/call-context.ts
@@ -349,7 +349,6 @@ export class CallContext {
         const copied = new Uint8Array(valueBlock.buffer.byteLength)
         copied.set(new Uint8Array(valueBlock.buffer), 0)
         this.setVariable(key, copied);
-        this[ENV].free(Number(valueaddr));
       } catch (err: any) {
         this.#logger.error(err.message)
         this.setError(err)

--- a/src/call-context.ts
+++ b/src/call-context.ts
@@ -296,7 +296,7 @@ export class CallContext {
 
       const key = item.string();
 
-      this[ENV].free(addr);
+      this[ENV].free(number(addr));
 
       if (key in this.#config) {
         return this.store(this.#config[key]);
@@ -313,7 +313,7 @@ export class CallContext {
       }
 
       const key = item.string();
-      this[ENV].free(addr);
+      this[ENV].free(number(addr));
 
       const result = this.getVariable(key);
       const stored = result ? this[STORE](result.bytes()) || 0 : 0;
@@ -329,7 +329,7 @@ export class CallContext {
       }
 
       const key = item.string();
-      this[ENV].free(addr);
+      this[ENV].free(number(addr));
 
       if (valueaddr === 0n) {
         this.deleteVariable(key)
@@ -349,7 +349,7 @@ export class CallContext {
         const copied = new Uint8Array(valueBlock.buffer.byteLength)
         copied.set(new Uint8Array(valueBlock.buffer), 0)
         this.setVariable(key, copied);
-        this[ENV].free(valueaddr);
+        this[ENV].free(number(valueaddr));
       } catch (err: any) {
         this.#logger.error(err.message)
         this.setError(err)
@@ -386,7 +386,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.warn(text);
-      this[ENV].free(addr);
+      this[ENV].free(number(addr));
     },
 
     log_info: (addr: bigint) => {
@@ -400,7 +400,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.info(text);
-      this[ENV].free(addr);
+      this[ENV].free(number(addr));
     },
 
     log_debug: (addr: bigint) => {
@@ -414,7 +414,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.debug(text);
-      this[ENV].free(addr);
+      this[ENV].free(number(addr));
     },
 
     log_error: (addr: bigint) => {
@@ -428,7 +428,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.error(text);
-      this[ENV].free(addr);
+      this[ENV].free(number(addr));
     },
   };
 

--- a/src/call-context.ts
+++ b/src/call-context.ts
@@ -329,7 +329,6 @@ export class CallContext {
       }
 
       const key = item.string();
-      this[ENV].free(Number(addr));
 
       if (valueaddr === 0n) {
         this.deleteVariable(key)

--- a/src/call-context.ts
+++ b/src/call-context.ts
@@ -296,7 +296,7 @@ export class CallContext {
 
       const key = item.string();
 
-      this[ENV].free(number(addr));
+      this[ENV].free(Number(addr));
 
       if (key in this.#config) {
         return this.store(this.#config[key]);
@@ -313,7 +313,7 @@ export class CallContext {
       }
 
       const key = item.string();
-      this[ENV].free(number(addr));
+      this[ENV].free(Number(addr));
 
       const result = this.getVariable(key);
       const stored = result ? this[STORE](result.bytes()) || 0 : 0;
@@ -329,7 +329,7 @@ export class CallContext {
       }
 
       const key = item.string();
-      this[ENV].free(number(addr));
+      this[ENV].free(Number(addr));
 
       if (valueaddr === 0n) {
         this.deleteVariable(key)
@@ -349,7 +349,7 @@ export class CallContext {
         const copied = new Uint8Array(valueBlock.buffer.byteLength)
         copied.set(new Uint8Array(valueBlock.buffer), 0)
         this.setVariable(key, copied);
-        this[ENV].free(number(valueaddr));
+        this[ENV].free(Number(valueaddr));
       } catch (err: any) {
         this.#logger.error(err.message)
         this.setError(err)
@@ -386,7 +386,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.warn(text);
-      this[ENV].free(number(addr));
+      this[ENV].free(Number(addr));
     },
 
     log_info: (addr: bigint) => {
@@ -400,7 +400,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.info(text);
-      this[ENV].free(number(addr));
+      this[ENV].free(Number(addr));
     },
 
     log_debug: (addr: bigint) => {
@@ -414,7 +414,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.debug(text);
-      this[ENV].free(number(addr));
+      this[ENV].free(Number(addr));
     },
 
     log_error: (addr: bigint) => {
@@ -428,7 +428,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.error(text);
-      this[ENV].free(number(addr));
+      this[ENV].free(Number(addr));
     },
   };
 

--- a/src/call-context.ts
+++ b/src/call-context.ts
@@ -296,6 +296,8 @@ export class CallContext {
 
       const key = item.string();
 
+      this.free(addr);
+
       if (key in this.#config) {
         return this.store(this.#config[key]);
       }
@@ -309,9 +311,10 @@ export class CallContext {
       if (item === null) {
         return 0n;
       }
-      this.free(addr);
 
       const key = item.string();
+      this.free(addr);
+
       const result = this.getVariable(key);
       const stored = result ? this[STORE](result.bytes()) || 0 : 0;
       return Block.indexToAddress(stored)
@@ -324,9 +327,9 @@ export class CallContext {
         this.#logger.error(`attempted to set variable using invalid key address (addr="${addr.toString(16)}H")`);
         return;
       }
-      this.free(addr);
 
       const key = item.string();
+      this.free(addr);
 
       if (valueaddr === 0n) {
         this.deleteVariable(key)
@@ -346,13 +349,12 @@ export class CallContext {
         const copied = new Uint8Array(valueBlock.buffer.byteLength)
         copied.set(new Uint8Array(valueBlock.buffer), 0)
         this.setVariable(key, copied);
+        this.free(valueaddr);
       } catch (err: any) {
         this.#logger.error(err.message)
         this.setError(err)
         return;
       }
-
-      this.free(valueaddr);
     },
 
     http_request: (_requestOffset: bigint, _bodyOffset: bigint): bigint => {

--- a/src/call-context.ts
+++ b/src/call-context.ts
@@ -204,7 +204,7 @@ export class CallContext {
       return this.alloc(n);
     },
 
-    free: (addr: number): void => {
+    free: (addr: number | bigint): void => {
       this.#blocks[Block.addressToIndex(addr)] = null;
     },
 
@@ -296,7 +296,7 @@ export class CallContext {
 
       const key = item.string();
 
-      this[ENV].free(Number(addr));
+      this[ENV].free(addr);
 
       if (key in this.#config) {
         return this.store(this.#config[key]);
@@ -313,7 +313,7 @@ export class CallContext {
       }
 
       const key = item.string();
-      this[ENV].free(Number(addr));
+      this[ENV].free(addr);
 
       const result = this.getVariable(key);
       const stored = result ? this[STORE](result.bytes()) || 0 : 0;
@@ -384,7 +384,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.warn(text);
-      this[ENV].free(Number(addr));
+      this[ENV].free(addr);
     },
 
     log_info: (addr: bigint) => {
@@ -398,7 +398,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.info(text);
-      this[ENV].free(Number(addr));
+      this[ENV].free(addr);
     },
 
     log_debug: (addr: bigint) => {
@@ -412,7 +412,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.debug(text);
-      this[ENV].free(Number(addr));
+      this[ENV].free(addr);
     },
 
     log_error: (addr: bigint) => {
@@ -426,7 +426,7 @@ export class CallContext {
       }
       const text = this.#decoder.decode(block.buffer);
       this.#logger.error(text);
-      this[ENV].free(Number(addr));
+      this[ENV].free(addr);
     },
   };
 


### PR DESCRIPTION
Updates `var`, `config` and `http_request` to free memory handles passed in as arguments

Similar to https://github.com/extism/extism/pull/743 and https://github.com/extism/go-sdk/pull/70