### PR TITLE
Uppercase the http method

### DIFF
--- a/src/http-context.ts
+++ b/src/http-context.ts
@@ -48,7 +48,7 @@ export class HttpContext {
     }
 
     const { headers, header, url: rawUrl, method: m } = req.json();
-    const method = m ?? 'GET';
+    const method = m?.toUpperCase() ?? 'GET';
     const url = new URL(rawUrl);
 
     const isAllowed = this.allowedHosts.some((allowedHost) => {


### PR DESCRIPTION
Unclear exactly if this is a problem here or if this is the right spot, but had an issue where googleapis.com didn't accept a lowercase http method from the client. gonna make sure the same is in go and rust.