### PR TITLE
fix(jspi): JSPI should not override http calls in worker context

### DIFF
--- a/src/foreground-plugin.ts
+++ b/src/foreground-plugin.ts
@@ -244,13 +244,17 @@ async function instantiateModule(
       // haven't overridden the default CallContext implementation, we provide an HttpContext
       // on-demand.
       //
-      // Unfortuantely this duplicates a little bit of logic-- in particular, we have to bind
+      // Unfortunately this duplicates a little bit of logic-- in particular, we have to bind
       // CallContext to each of the HttpContext contributions (See "REBIND" below.)
+      //
+      // Notably, if we're calling this from a background thread, skip all of the patching:
+      // we want to dispatch to the main thread.
       if (
         module === EXTISM_ENV &&
         name === 'http_request' &&
         promising &&
-        imports[module][name] === context[ENV].http_request
+        imports[module][name] === context[ENV].http_request &&
+        !opts.executingInWorker
       ) {
         const httpContext = new HttpContext(opts.fetch, opts.allowedHosts, opts.memory, opts.allowHttpResponseHeaders);
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -287,6 +287,7 @@ export interface InternalConfig extends Required<NativeManifestOptions> {
   sharedArrayBufferSize: number;
   allowHttpResponseHeaders: boolean;
   nodeWorkerArgs: NodeWorkerArgs;
+  executingInWorker: boolean;
 }
 
 export interface InternalWasi {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -136,6 +136,7 @@ export async function createPlugin(
   }
 
   const ic: InternalConfig = {
+    executingInWorker: false,
     allowedHosts: opts.allowedHosts as [],
     allowedPaths: opts.allowedPaths,
     functions: opts.functions,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -155,7 +155,7 @@ class Reactor {
 
     // TODO: replace our internal fetch and logger
     this.plugin = await _createForegroundPlugin(
-      { ...opts, functions, fetch, logger } as InternalConfig,
+      { ...opts, functions, fetch, logger, executingInWorker: true } as InternalConfig,
       ev.names,
       modules,
       this.context,


### PR DESCRIPTION
This fixes a bug where we'd use the system `fetch` inside a plugin run in a worker when JSPI was enabled, bypassing overrides of the `fetch` function.